### PR TITLE
Switch tests to pytest testing framework

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: [ master, wiki ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, wiki ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,15 +23,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - run: sudo apt-get update
       - run: pip install -r requirements-dev.txt
       - run: python dashboards/tests/fetch_config.py https://devxnat.barcelonabeta.org --xnat_user $XNAT_USER --xnat_password $XNAT_PASSWORD
         env:
           XNAT_USER: ${{ secrets.XNAT_USER }}
           XNAT_PASSWORD: ${{ secrets.XNAT_PASSWORD }}
-      - run: nosetests dashboards/tests --nocapture --nologcapture --with-coverage --cover-erase --cover-inclusive --cover-package .
+      - run: pytest
         env:
           CI_TEST: 0
           PYTHONPATH: $PYTHONPATH:$(pwd)

--- a/dashboards/tests/tests.py
+++ b/dashboards/tests/tests.py
@@ -37,7 +37,7 @@ def test_001_pickle_save():  # should be run first
 
 def test_002_pickle_project_data():
 
-    c = pyxnat.Interface(server='https://central.xnat.org', anonymous=True)
+    c = pyxnat.Interface(server='https://www.nitrc.org/ir', anonymous=True)
     projects = pk.get_projects(c)
 
     p = projects.pop()
@@ -53,7 +53,7 @@ def test_002_pickle_project_data():
 
 def test_003_pickle_subject_data():
 
-    c = pyxnat.Interface(server='https://central.xnat.org', anonymous=True)
+    c = pyxnat.Interface(server='https://www.nitrc.org/ir', anonymous=True)
     subjects = pk.get_subjects(c)
 
     s = subjects.pop()
@@ -63,7 +63,7 @@ def test_003_pickle_subject_data():
 
 def test_004_pickle_experiment_data():
 
-    c = pyxnat.Interface(server='https://central.xnat.org', anonymous=True)
+    c = pyxnat.Interface(server='https://www.nitrc.org/ir', anonymous=True)
     experiments = pk.get_experiments(c)
 
     e = experiments.pop()
@@ -74,7 +74,7 @@ def test_004_pickle_experiment_data():
 
 def test_005_pickle_scan_data():
 
-    c = pyxnat.Interface(server='https://central.xnat.org', anonymous=True)
+    c = pyxnat.Interface(server='https://www.nitrc.org/ir', anonymous=True)
     scans = pk.get_scans(c)
 
     s = scans.pop()
@@ -86,7 +86,7 @@ def test_005_pickle_scan_data():
 
 def test_006_pickle_resource_data():
 
-    c = pyxnat.Interface(server='https://central.xnat.org', anonymous=True)
+    c = pyxnat.Interface(server='https://www.nitrc.org/ir', anonymous=True)
     resources = pk.get_resources(c)
 
     r = resources.pop()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = dashboards/tests
+python_files = tests.py
+python_functions = test_*
+addopts =
+    -ra -q
+    --cov=dashboards
+    --cov-report=term-missing
+    --cov-report=html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 lxml>=4.6.3
 tqdm>=4.48
 Flask>=2.0
-pyxnat>=1.3
+pyxnat>=1.6
+nibabel>=3.1
 pandas>=1.3
 requests>=2.26
 openpyxl>=3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ pandas>=1.3
 requests>=2.26
 openpyxl>=3.0
 #testing
-nose>=1.2.1
+pytest>=7.1
+pytest-cov>=4.0
 coverage>=3.6
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 lxml>=4.6.3
 tqdm>=4.48
 Flask>=2.0
-pyxnat>=1.3
+pyxnat>=1.6
+nibabel>=3.1
 pandas>=1.3
 requests>=2.26
 openpyxl>=3.0


### PR DESCRIPTION
Migrating testing framework from ([nose](https://nose.readthedocs.io/)) to [pytest](https://pytest.org/) framework.

Nose development has been [discontinued](https://nose.readthedocs.io/en/latest/#note-to-users) and is not actively maintained anymore, which could lead to future problems for this project and its dependencies. On the other hand, pytest is currently an actively maintained and widely used framework for functional testing. Supports running legacy unittest tests (and nose), so switching our tests to pytest is an -almost- straight-forward choice.